### PR TITLE
Fix first_server startup failure caused by directory renaming

### DIFF
--- a/first_server.js
+++ b/first_server.js
@@ -4,7 +4,7 @@ var http = require('http')
     , app = express()
     , systemd = require('systemd');
 
-app.use(express.static(__dirname + '/dollhouse'));
+app.use(express.static(__dirname + '/gateway-webui'));
 
 var fs = require('fs');
 var vm = require('vm');
@@ -13,7 +13,7 @@ var includeInThisContext = function(path) {
     vm.runInThisContext(code, path);
 }.bind(this);
 
-var rules = require('./dollhouse/rules_engine');
+var rules = require('./gateway-webui/rules_engine');
 
 var fs = require('fs');
 console.log(__dirname + "/data.json");


### PR DESCRIPTION
This fixes the server startup failure caused by directory renaming.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>