### PR TITLE
 Call subscribe() method to enable global presence flag

### DIFF
--- a/first_server.js
+++ b/first_server.js
@@ -206,7 +206,13 @@ function discoverResources() {
     notifyObserversTimeoutId = setTimeout(discoverResources, 5000);
 }
 
-discoverResources();
+device.subscribe().then(
+    function() {
+       discoverResources();
+    },
+    function(error) {
+        debuglog('device.subscribe() failed with: ' + error);
+    });
 
 // Exit gracefully when interrupted
 process.on('SIGINT', function() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": { 
-	"iotivity-node": "^1.1.0-3",
+	"iotivity-node": "^1.1.0-4",
 	"express": "*",
 	"websocket": "*",
 	"http": "*",


### PR DESCRIPTION
Call subscribe() method to enable global presence, so that the client will receive device presence notifications "added", "deleted", "changed"

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>