### PR TITLE
Dockerfile: fix URL for cloning SmartHome-Demo repo

### DIFF
--- a/smarthome-web-portal/tools/docker/Dockerfile
+++ b/smarthome-web-portal/tools/docker/Dockerfile
@@ -62,8 +62,6 @@ RUN git clone --progress "https://$git_token@$git_url" /opt/SmartHome-Demo
 
 ADD web-portal.conf /etc/supervisor/conf.d/web-portal.conf
 
-# ADD initial_db.py /opt/smarthome-web-portal/initial_db.py
-
 WORKDIR /opt/SmartHome-Demo/smarthome-web-portal
 
 # install portal dependencies
@@ -82,7 +80,7 @@ ADD utils.py tools/smarthome-admin-portal/admin/utils.py
 ENV http_proxy ""
 ENV https_proxy ""
 
-ENV PYTHONPATH $PYTHONPATH:/opt/smarthome-web-portal
+ENV PYTHONPATH $PYTHONPATH:/opt/SmartHome-Demo/smarthome-web-portal
 
 # start supervisor
 CMD ["/usr/bin/supervisord", "-n"]

--- a/smarthome-web-portal/tools/docker/Dockerfile
+++ b/smarthome-web-portal/tools/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV http_proxy ${http_proxy}
 
 ENV https_proxy ${https_proxy}
 
-ENV git_url "https://github.com/01org/SmartHome-Demo.git"
+ENV git_url "github.com/01org/SmartHome-Demo.git"
 
 RUN echo $https_proxy 
 


### PR DESCRIPTION
The URL listed in the Dockerfile (smarthome-web-portal/tools/docker)
leads to an error when attempting to build the container image. An
extra "https://" gets inserted and makes cloning the SmartHome-Demo
fail.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>