### PR TITLE
Remove sleep in web-portal.conf and add a startup script.

### DIFF
--- a/smarthome-web-portal/tools/docker/Dockerfile
+++ b/smarthome-web-portal/tools/docker/Dockerfile
@@ -61,6 +61,7 @@ RUN echo "https://$git_token@$git_url"
 RUN git clone --progress "https://$git_token@$git_url" /opt/SmartHome-Demo
 
 ADD web-portal.conf /etc/supervisor/conf.d/web-portal.conf
+ADD start-service.sh /opt/SmartHome-Demo/smarthome-web-portal/start-service.sh
 
 WORKDIR /opt/SmartHome-Demo/smarthome-web-portal
 

--- a/smarthome-web-portal/tools/docker/start-service.sh
+++ b/smarthome-web-portal/tools/docker/start-service.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# The script is to let the process wait until the dependency process starts up.
+
+function wait_service()
+{
+    # Wait until the service gets started.
+    while ! nc -z localhost $2; do
+        echo "Waiting for $1 to start ..."
+        sleep 1
+    done
+    echo "$1 started."
+}
+
+function start_service()
+{
+    case $1 in
+        rabbitmq)
+            wait_service 'MySQL' '3306'
+            echo "Starting $1 server."
+            /usr/sbin/rabbitmq-server
+            ;;
+        celery-worker)
+            wait_service 'MySQL' '3306'
+            wait_service 'Rabbitmq' '5672'
+            echo "Starting $1 server."
+            /usr/local/bin/celery -A CeleryTask.tasks purge -f
+            sleep 3
+            /usr/bin/python2.7 CeleryTask/tasks.py
+            sleep 3
+            /usr/local/bin/celery -A CeleryTask.celeryapp worker -l info
+            ;;
+        web-portal)
+            wait_service 'MySQL' '3306'
+            /usr/bin/python2.7 initial_db.py
+            /usr/bin/python2.7 SHProject.py
+            ;;
+        *)
+            echo "Unknown service: $1."
+            ;;
+    esac
+}
+
+start_service $1

--- a/smarthome-web-portal/tools/docker/web-portal.conf
+++ b/smarthome-web-portal/tools/docker/web-portal.conf
@@ -16,7 +16,7 @@ stdout_logfile_maxbytes=0
 
 [program:web-portal]
 priority=998
-command=/bin/bash -c "/bin/sleep 10 && /usr/bin/python2.7 initial_db.py && /usr/bin/python2.7 SHProject.py"
+command=./start-service.sh web-portal
 directory=/opt/SmartHome-Demo/smarthome-web-portal/
 autostart=true
 autorestart=true
@@ -26,7 +26,7 @@ stdout_logfile_maxbytes=0
 
 [program:rabbitmq]
 priority=2
-command=/bin/bash -c "/bin/sleep 10 && /usr/sbin/rabbitmq-server"
+command=./start-service.sh rabbitmq
 user=root
 autostart=true
 autorestart=unexpected
@@ -34,7 +34,7 @@ stopsignal=QUIT
 
 [program:celery-worker]
 priority=999
-command=/bin/bash -c "/bin/sleep 20 && /usr/local/bin/celery -A CeleryTask.tasks purge -f && /usr/bin/python2.7 CeleryTask/tasks.py && /usr/local/bin/celery -A CeleryTask.celeryapp worker -l info" 
+command=./start-service.sh celery-worker 
 directory=/opt/SmartHome-Demo/smarthome-web-portal/
 autostart=true
 autorestart=true


### PR DESCRIPTION
Hi, @gvancuts. In order to solve the issue #42, I worte a startup script to start the process only when the dependency processes are running. 
And I also rebuilt the image and created a new [repo](https://hub.docker.com/r/smarthome2cloud/smarthome-demo-pr37/) in Docker Hub for it. You may want to get the image by the command `docker pull smarthome2cloud/smarthome-demo-pr37:wait-service` to test it. 
