### PR TITLE
power-uart.js: Fix the ReferenceError in mraa UART mode

### DIFF
--- a/ocf-servers/js-servers/power-uart.js
+++ b/ocf-servers/js-servers/power-uart.js
@@ -58,7 +58,7 @@ if (!noble) {
          */
         args = process.argv.slice(2);
         args.forEach(function(entry) {
-            dev = entry;
+            serialDev = entry;
         });
     }
 }
@@ -170,7 +170,7 @@ function setupHardware() {
         });
     }
     else if (mraa) {
-        uart = new mraa.Uart(dev);
+        uart = new mraa.Uart(serialDev);
         uart.setBaudRate(115200);
         uart.setMode(8, 0, 1);
         uart.setFlowcontrol(false, false);


### PR DESCRIPTION
power-uart.js was failing to start when mraa UART is used instead of BLE. The issue was introduced when BLE code was added. 

```
$ node power-uart.js 
No noble module: Cannot find module 'noble'. Switching to wire connection.
SmartHome-Demo/ocf-servers/js-servers/power-uart.js:173
        uart = new mraa.Uart(dev);
                             ^

ReferenceError: dev is not defined
    at setupHardware (SmartHome-Demo/ocf-servers/js-servers/power-uart.js:173:30)

```  
Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>