### PR TITLE
OCF JS servers: add command-line arg to force simulation mode

### DIFF
--- a/ocf-servers/js-servers/ambient_light.js
+++ b/ocf-servers/js-servers/ambient_light.js
@@ -22,15 +22,29 @@ var device = require('iotivity-node'),
     resourceInterfaceName = '/a/illuminance',
     hasUpdate = false,
     observerCount = 0,
-    lux = 0.0;
+    lux = 0.0,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup ambient light sensor pin.
@@ -45,14 +59,13 @@ function setupHardware() {
 // the GET request received from the client.
 function getProperties() {
     var temp = 0;
-    if (mraa) {
+    if (!simulationMode) {
         var raw_value = sensorPin.read();
 
         // Conversion to lux
         temp = 10000.0 / Math.pow(((1023.0 - raw_value) * 10.0 / raw_value) * 15.0, 4.0 / 3.0);
     } else {
-        // Simulate real sensor behavior. This is
-        // useful for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         temp = lux + 0.1;
     }
 

--- a/ocf-servers/js-servers/button-toggle.js
+++ b/ocf-servers/js-servers/button-toggle.js
@@ -29,15 +29,29 @@ var device = require('iotivity-node'),
     observerCount = 0,
     hasUpdate = false,
     sensorState = false,
-    prevState = false;
+    prevState = false,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Button pin.
@@ -53,7 +67,7 @@ function setupHardware() {
 // the GET request received from the client.
 function getProperties() {
 
-    if (mraa) {
+    if (!simulationMode) {
         var buttonState = (sensorPin.read() == 1) ? true : false;
 
         // We care only when the button state is different.
@@ -71,8 +85,7 @@ function getProperties() {
             }
         }
     } else {
-        // Simulate real sensor behavior. This is
-        // useful for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         sensorState = !sensorState;
         hasUpdate = true;
     }

--- a/ocf-servers/js-servers/button.js
+++ b/ocf-servers/js-servers/button.js
@@ -22,15 +22,29 @@ var device = require('iotivity-node'),
     resourceInterfaceName = '/a/button',
     observerCount = 0,
     hasUpdate = false,
-    sensorState = false;
+    sensorState = false,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Button pin.
@@ -47,14 +61,13 @@ function setupHardware() {
 function getProperties() {
     var buttonState = false;
 
-    if (mraa) {
+    if (!simulationMode) {
         if (sensorPin.read() == 1)
             buttonState = true;
         else
             buttonState = false;
     } else {
-        // Simulate real sensor behavior. This is
-        // useful for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         buttonState = !sensorState;
     }
 

--- a/ocf-servers/js-servers/buzzer.js
+++ b/ocf-servers/js-servers/buzzer.js
@@ -22,15 +22,29 @@ var device = require('iotivity-node'),
     exitId,
     sensorState = false,
     resourceTypeName = 'oic.r.buzzer',
-    resourceInterfaceName = '/a/buzzer';
+    resourceInterfaceName = '/a/buzzer',
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Buzzer sensor pin.
@@ -60,7 +74,7 @@ function updateProperties(properties) {
 
     debuglog('Update received. value: ', sensorState);
 
-    if (!mraa)
+    if (simulationMode)
         return;
 
     if (sensorState) {

--- a/ocf-servers/js-servers/fan.js
+++ b/ocf-servers/js-servers/fan.js
@@ -20,15 +20,29 @@ var device = require('iotivity-node'),
     observerCount = 0,
     sensorState = false,
     resourceTypeName = 'oic.r.fan',
-    resourceInterfaceName = '/a/fan';
+    resourceInterfaceName = '/a/fan',
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Fan sensor pin.
@@ -47,7 +61,7 @@ function updateProperties(properties) {
 
     debuglog('Update received. value: ', sensorState);
 
-    if (!mraa)
+    if (simulationMode)
         return;
 
     if (sensorState)

--- a/ocf-servers/js-servers/gas.js
+++ b/ocf-servers/js-servers/gas.js
@@ -23,15 +23,29 @@ var device = require('iotivity-node'),
     exitId,
     observerCount = 0,
     hasUpdate = false,
-    gasDetected = false;
+    gasDetected = false,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Gas sensor pin.
@@ -45,7 +59,7 @@ function setupHardware() {
 // This function construct the payload and returns when
 // the GET request received from the client.
 function getProperties() {
-    if (mraa) {
+    if (!simulationMode) {
         val = sensorPin.read();
         density = val * 500 / 1024;
 
@@ -62,8 +76,7 @@ function getProperties() {
             }
         }
     } else {
-        // Simulate real sensor behavior. This is useful
-        // for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         gasDetected = !gasDetected;
         hasUpdate = true;
     }

--- a/ocf-servers/js-servers/led.js
+++ b/ocf-servers/js-servers/led.js
@@ -20,15 +20,29 @@ var device = require('iotivity-node'),
     observerCount = 0,
     sensorState = false,
     resourceTypeName = 'oic.r.led',
-    resourceInterfaceName = '/a/led';
+    resourceInterfaceName = '/a/led',
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup LED sensor pin.
@@ -47,7 +61,7 @@ function updateProperties(properties) {
 
     debuglog('Update received. value: ', sensorState);
 
-    if (!mraa)
+    if (simulationMode)
         return;
 
     if (sensorState)

--- a/ocf-servers/js-servers/motion.js
+++ b/ocf-servers/js-servers/motion.js
@@ -23,15 +23,29 @@ var device = require('iotivity-node'),
     observerCount = 0,
     hasUpdate = false,
     noObservers = false,
-    sensorState = false;
+    sensorState = false,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup Motion sensor pin.
@@ -48,14 +62,13 @@ function setupHardware() {
 function getProperties() {
     var motion = false;
 
-    if (mraa) {
+    if (!simulationMode) {
         if (sensorPin.read() > 0)
             motion = true;
         else
             motion = false;
     } else {
-        // Simulate real sensor behavior. This is
-        // useful for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         motion = !sensorState;
     }
 

--- a/ocf-servers/js-servers/rgb_led.js
+++ b/ocf-servers/js-servers/rgb_led.js
@@ -24,15 +24,29 @@ var device = require('iotivity-node'),
     range = [0,255],
     rgbValue = [0,0,0],
     clockPin,
-    dataPin;
+    dataPin,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup LED pin.
@@ -130,7 +144,7 @@ function updateProperties(properties) {
     if (!checkColour(r) || !checkColour(g) || !checkColour(b))
         return;
 
-    if (mraa)
+    if (!simulationMode)
         setColourRGB(r, g, b);
     rgbValue = input;
 

--- a/ocf-servers/js-servers/solar.js
+++ b/ocf-servers/js-servers/solar.js
@@ -27,21 +27,39 @@ var device = require('iotivity-node'),
     observerCount = 0,
     solarProperties = {};
 
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
+
+
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 var lcd = '';
-try {
-    lcd = require('jsupm_i2clcd');
-}
-catch (e) {
-    debuglog('No lcd module: ', e.message);
+if (!simulationMode) {
+    try {
+        lcd = require('jsupm_i2clcd');
+    }
+    catch (e) {
+        debuglog('No lcd module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 function resetLCDScreen() {

--- a/ocf-servers/js-servers/switch.js
+++ b/ocf-servers/js-servers/switch.js
@@ -23,15 +23,29 @@ var device = require('iotivity-node'),
     observerCount = 0,
     hasUpdate = false,
     noObservers = false,
-    sensorState = false;
+    sensorState = false,
+    simulationMode = false;
+
+// Parse command-line arguments
+var args = process.argv.slice(2);
+args.forEach(function(entry) {
+    if (entry === "--simulation" || entry === "-s") {
+        simulationMode = true;
+        debuglog('Running in simulation mode');
+    };
+});
 
 // Require the MRAA library
 var mraa = '';
-try {
-    mraa = require('mraa');
-}
-catch (e) {
-    debuglog('No mraa module: ', e.message);
+if (!simulationMode) {
+    try {
+        mraa = require('mraa');
+    }
+    catch (e) {
+        debuglog('No mraa module: ', e.message);
+        debuglog('Automatically switching to simulation mode');
+        simulationMode = true;
+    }
 }
 
 // Setup binary switch pin.
@@ -48,14 +62,13 @@ function setupHardware() {
 function getProperties() {
     var switchState = false;
 
-    if (mraa) {
+    if (!simulationMode) {
         if (sensorPin.read() >= 1)
             switchState = true;
         else
             switchState = false;
     } else {
-        // Simulate real sensor behavior. This is
-        // useful for testing on desktop without mraa.
+        // Simulate real sensor behavior. This is useful for testing.
         switchState = !sensorState;
     }
 


### PR DESCRIPTION
Add a command-line argument to make them operate in simulation
mode irrespective of whether the required node modules are installed.
This is useful if you have some of these installed (e.g. mraa or
noble) but don't want to use them.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>