### PR TITLE
gateway: enable cli arguments for the IoT REST API Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ In this case, you can check that the virtual Home Gateway is running by checking
 
 The advantage of running with the `--network host` parameter is that the virtual gateway should see other OCF servers available on your local network (not just the ones from your container environment).
 
-*Note:* this uses plain HTTP. It is possible to use HTTPS by modifying the [startup script](gateway/start-smarthome-in-docker.sh) and passing the `-s` parameter to the `iot-rest-api-server` startup script.
+*Note:* this uses plain HTTP by default. It is possible to use HTTPS by giving the container the `-s` command-line argument; we can only **strongly** advise that you also provide a valid `certificate.pem` and `private.key` when doing so. Please check this [README.md](gateway/README.md) file for more details on how to do that.
 
-By default, the [startup script](ocf-servers/start-ocf-servers-in-docker.sh) starts all the OCF servers. In order to selectively start some of the OCF servers, follow the steps below:
+*Note2:* similarly to what's described in the note above, you can tweak the behaviour of the `iot-rest-api-server` (e.g. changing the default port) by passing command-line arguments to the container, these are passed on as-is to the [IoT REST API Server] service.
+
+By default, the [startup script](ocf-servers/start-ocf-servers-in-docker.sh) in the `smarthome-sensors` Docker container starts all the OCF servers in `ocf-servers/js-servers/`. In order to selectively start some of the OCF servers, or start multiple instances of some, follow the steps below:
 1. Make a copy of the `ocf-servers/ocf-server.conf.template` file and rename it to `ocf-servers/ocf-server.conf`
 2. Configure `ocf-servers/ocf-server.conf` adhering to the format as shown in the template. Put the OCF server name in the 1st column and the total number of the specified server type in the 2nd column. If the configuration file format is not compliant or it does not exist in the same directory as the script file, the [startup script](ocf-servers/start-ocf-servers-in-docker.sh) skips parsing and starts all OCF servers instead.
 3. Share the configuration file on the host with the container process    

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -31,6 +31,9 @@ WORKDIR /opt/SmartHome-Demo/gateway/
 
 RUN npm install
 
+# Install the certificates needed when using HTTPS
+RUN /bin/bash /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/generate-key-and-cert.sh
+
 # Forward port
 EXPOSE 8000 8080
 
@@ -39,5 +42,5 @@ ENV http_proxy ""
 ENV https_proxy ""
 
 # Start Home Gateway
-CMD ["/opt/SmartHome-Demo/gateway/start-gateway-in-docker.sh"]
+ENTRYPOINT ["/opt/SmartHome-Demo/gateway/start-gateway-in-docker.sh"]
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -31,8 +31,7 @@ WORKDIR /opt/SmartHome-Demo/gateway/
 
 RUN npm install
 
-# Install the certificates needed when using HTTPS
-RUN /bin/bash /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/generate-key-and-cert.sh
+VOLUME ["/opt/security-files/"]
 
 # Forward port
 EXPOSE 8000 8080

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -12,11 +12,35 @@ This README.md only covers options 1. and 3. Deploying the SmartHome Gateway via
 
 In order to make deploying the SmartHome Gateway easy, a [Docker] container has been created and is available on [Docker Hub](https://hub.docker.com). It is called [smarthome2cloud/smarthome-gateway](https://hub.docker.com/r/smarthome2cloud/smarthome-gateway/). You will find more detailed instructions on how to pull it and run it in the [top-level README.md](../README.md).
 
+### User manual
+
+There is some generic information on how to create and run the different [Docker] containers that are part of this set-up in the top-level [README.d](../README.me) file. We won't repeat much of the same information here and we will instead give a concrete example of how you can quickly get the Home Gateway function up and running using [Docker].
+
+The starting point is a host machine that has [Docker] installed in it. From that point on, follow these simple steps:
+```
+$ sudo docker pull smarthome2cloud/smarthome-gateway
+$ sudo docker run --net host smarthome2cloud/smarthome-gateway
+```
+And that's it! You can verify that the Home Gateway function is up and running by checking http://localhost:8000/api/system from your favourite browser. The page should display information about your system.
+
+By default, the Home Gateway uses HTTP and port 8000, you can actually change that by passing command-line arguments to the container. It will accept all command-line arguments that the [IoT REST API Server] accepts.
+
+Should you wish to use HTTPS instead of HTTP, you can use the `-s` command-line argument. It is **highly** recommended in such case that you also provide a private key (`private.key`) and certificate (`certificate.pem`) from a known certificate authority. If you don't, a key and certificate will be auto-generated but should be used for testing only. You will get warnings when using them. Assuming you have a valid key and certificate, here is how you can pass them on to the [Docker] container:
+1. Create a folder on your host and place both `certificate.pem` and `private.key` in it (you **must** use these exact filenames).
+2. Start the [Docker] container exposing this folder to the `/opt/security-files` folder inside the container.
+Here is a concrete example, using HTTPS and port 9000:
+```
+$ sudo docker run -v /path/to/host/folder:/opt/security-files --net host smarthome2cloud/smarthome-gateway -p 9000 -s
+```
+Go to https://localhost:9000/api/system to verify that the Home Gateway is indeed up and running.
+
+### Technical description
+
 Internally, this [Docker] container uses the [`start-gateway-in-docker.sh`](./start-gateway-in-docker.sh) script to start the following couple of services:
 * Home Gateway SW: the core is provided by the content of this folder and started by the [`gateway-server.js`](./gateway-server.js) script
 * [IoT REST API Server]: this is the service that exposes the OIC (OCF) API over HTTP(S)
 
-The [IoT REST API Server] can take a number of command-line arguments that tweak its behaviour, by default it starts on port 8000 using 'http'. Should you want to change any of these, you can pass any of the [IoT REST API Server] command-line arguments to the [Docker] container and they will be used. The command-line arguments that are available today are:
+The [IoT REST API Server] can take a number of command-line arguments that tweak its behaviour, by default it starts on port 8000 using HTTP. Should you want to change any of these, you can pass any of the [IoT REST API Server] command-line arguments to the [Docker] container and they will be used. The command-line arguments that are available today are:
 ```
 usage: node index.js [options]
 options:
@@ -44,7 +68,7 @@ Node.js dependencies can be installed using `npm install <node_module>` (you nee
 * [WebSocket](https://www.npmjs.com/package/websocket)
 * [mraa](https://www.npmjs.com/package/mraa): this is only needed if you want to use the Smart Power Meter with a serial line connection. See this [README.md](../sensors//DC_power_meter/README.md) for more details on the Smart Power Meter.
 
-## How to start the Home GW SW
+### How to start the Home GW SW
 
 1. Transfer the content of this repo to your Home Gateway (e.g. `git clone https://github/01org/SmartHome-Demo`)
 2. Install all `node.js` dependencies (see above)

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,19 +1,48 @@
 # The Home Gateway
 
-The demo was built leveraging the [Ostro OS
-Project](https://ostroproject.org/) and we recommend you use it to build your
-own demo.
-Ostro is a Linux operating system tailored for IoT
-smart devices and it fulfills many of the software stack requirements to run
-this demo out of the box.
+The Home Gateway can run on a variety of Operating Systems (OS), from Linux-based OS such as [Ubuntu](https://www.ubuntu.com/) or [Yocto](https://www.yoctoproject.org/) to Windows and Mac OS. This is possible thanks to the [Docker] container set-up which is described below. There are three ways you can set-up the Home Gateway function, in no particular order:
 
-## Node.js dependencies
+1. [Docker] container
+2. [Snap](https://snapcraft.io/) package
+3. Native installation
+
+This README.md only covers options 1. and 3. Deploying the SmartHome Gateway via [`snap`](https://snapcraft.io/) is described in great details in this [README.md](../snap/README.md). We shall note that using the [Docker] container or [`snap`](https://snapcraft.io/) package is the quickest way to do it so this is what we recommend you do for the very first time.
+
+## SmartHome Gateway in a [Docker] container
+
+In order to make deploying the SmartHome Gateway easy, a [Docker] container has been created and is available on [Docker Hub](https://hub.docker.com). It is called [smarthome2cloud/smarthome-gateway](https://hub.docker.com/r/smarthome2cloud/smarthome-gateway/). You will find more detailed instructions on how to pull it and run it in the [top-level README.md](../README.md).
+
+Internally, this [Docker] container uses the [`start-gateway-in-docker.sh`](./start-gateway-in-docker.sh) script to start the following couple of services:
+* Home Gateway SW: the core is provided by the content of this folder and started by the [`gateway-server.js`](./gateway-server.js) script
+* [IoT REST API Server]: this is the service that exposes the OIC (OCF) API over HTTP(S)
+
+The [IoT REST API Server] can take a number of command-line arguments that tweak its behaviour, by default it starts on port 8000 using 'http'. Should you want to change any of these, you can pass any of the [IoT REST API Server] command-line arguments to the [Docker] container and they will be used. The command-line arguments that are available today are:
+```
+usage: node index.js [options]
+options:
+  -h, --help
+  -v, --verbose
+  -p, --port <number>
+  -s, --https
+  -c, --cors
+```
+
+For more details, please take a look at the [Dockerfile](./Dockerfile).
+
+## Native installation
+
+A native installation assumes that you have [node.js](https://nodejs.org/) running on your system, please refer to the [node.js](https://nodejs.org/) website or your OS documentation for how to install it. Once [node.js](https://nodejs.org/) is installed, please proceed to the following sections to:
+1. Install the node.js dependencies
+2. Start the SmartHome Gateway services
+
+### Node.js dependencies
 
 Node.js dependencies can be installed using `npm install <node_module>` (you need a live network connection) for those not already provided by the OS.
+* [IoT REST API Server]
+* [IoTivity-node](https://www.npmjs.com/package/iotivity-node): this is in fact automatically pulled in when installing the [IoT REST API Server]
 * [Express](https://www.npmjs.com/package/express)
 * [WebSocket](https://www.npmjs.com/package/websocket)
-* [IoTivity-node](https://www.npmjs.com/package/iotivity-node) (already provided in Ostro)
-* [mraa](https://www.npmjs.com/package/mraa)
+* [mraa](https://www.npmjs.com/package/mraa): this is only needed if you want to use the Smart Power Meter with a serial line connection. See this [README.md](../sensors//DC_power_meter/README.md) for more details on the Smart Power Meter.
 
 ## How to start the Home GW SW
 
@@ -26,11 +55,5 @@ Node.js dependencies can be installed using `npm install <node_module>` (you nee
     node gateway/gateway-server.js -r # Start server with rules engine only.
 ```
 
-## SmartHome Gateway in a [Docker] container
-The [`start-gateway-in-docker.sh`](./start-gateway-in-docker.sh) script is used when building a Docker container that runs the Gateway functions. The following services are started by the script:
-* Home Gateway SW: the core is provided by the content of this folder and started by the [`gateway-server.js`](./gateway-server.js) script.
-* [IoT REST API Server](https://github.com/01org/iot-rest-api-server): this is the service that exposes OIC (OCF) API over HTTP(S)
-
-For more details, please take a look at the [Dockerfile](./Dockerfile).
-
 [Docker]: https://www.docker.com/
+[IoT REST API Server]: https://github.com/01org/iot-rest-api-server

--- a/gateway/start-gateway-in-docker.sh
+++ b/gateway/start-gateway-in-docker.sh
@@ -11,7 +11,9 @@ export NODE_PATH=/opt/SmartHome-Demo/gateway/node_modules/
 sleep 0.2
 
 # Start IoT REST API server
-/usr/bin/node /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/index.js &
+echo "Starting the IoT REST API Server..."
+# We blindly pass all container command-line arguments to the IoT REST API Server
+/usr/bin/node /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/index.js "$@" &
 
 keepgoing=true
 

--- a/gateway/start-gateway-in-docker.sh
+++ b/gateway/start-gateway-in-docker.sh
@@ -11,13 +11,48 @@ export NODE_PATH=/opt/SmartHome-Demo/gateway/node_modules/
 sleep 0.2
 
 # Start IoT REST API server
-echo "Starting the IoT REST API Server..."
+
+# First we will check if we were given a certificate and private key
+if [ -f "/opt/security-files/certificate.pem" \
+	-a -f "/opt/security-files/private.key" ]
+then
+	echo "Certificate and private key successfully found."
+	cp -f /opt/security-files/certificate.pem /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/
+	cp -f /opt/security-files/private.key /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/
+else
+	for arg in "$@"
+	do
+		if [ "$arg" = "-s" ]
+		then
+			echo
+			echo "*** WARNING ***"
+			echo
+			echo "No certificate or private key was found although you are requesting to use 'https'. We highly recommended that you provide a valid certificate and private key."
+			echo
+			echo "We will proceed using a certificate and private key that was generated for testing purposes only but be aware that the certificate is self-signed and browsers do not recognise it so you will get warnings."
+			echo
+			echo "We highly recommend that you get a proper certificate from a known certificate authority and its corresponding private key if you want to use 'https'"
+			echo
+			echo "If/once you have those, you can provide those by exposing a folder hosting both your 'private.key' and 'certificate.pem' (using these *exact filenames* and sharing it with this container under '/opt/security-files' using a data volume."
+			echo
+			echo "Here is an example of how to do just that:"
+			echo
+			echo "   $ sudo docker run -v /path/to/your/folder:/opt/security-files smarthome2cloud/smarthome-gateway -s"
+			echo
+			echo "*** Now that you have been warned, swiftly moving on... ***"
+
+			# This generate certificates for testing purposes (highly unsecured)
+			/bin/bash /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/generate-key-and-cert.sh
+		fi
+	done
+fi
+
 # We blindly pass all container command-line arguments to the IoT REST API Server
 /usr/bin/node /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/index.js "$@" &
 
 keepgoing=true
 
-trap "keepgoing=false" SIGINT
+trap "keepgoing=false" SIGINT SIGTERM SIGHUP SIGQUIT
 
 echo "Press [CTRL+C] to stop.."
 
@@ -25,3 +60,8 @@ while $keepgoing
 do
 	:
 done
+
+echo "Cleaning up certificate and private key inside the container and exiting..."
+rm -f /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/private.key
+rm -f /opt/SmartHome-Demo/gateway/node_modules/iot-rest-api-server/config/certificate.pem
+echo "Done... bye!"

--- a/smarthome-web-portal/tools/docker/README.md
+++ b/smarthome-web-portal/tools/docker/README.md
@@ -12,15 +12,15 @@ Here are the steps to run the Smart Home Web Portal in a Docker container.
     * Get in the `smarthome-web-portal` portal: `$ cd SmartHome-Demo/smarthome-web-portal`
 
 2. Configurations
-    * Update the preferred source in source.list    
+    * Update the preferred source in source.list
       eg. change `archive.ubuntu.com` to `hk.archive.ubuntu.com`
 
 3. Getting the Docker image
    There are two options (described in step 3.1 and 3.2 respectively) to get the Docker image. We recommend using option 3.1 as it is simpler and quicker.
 
 + 3.1 Pre-built Docker image
-    * Download the pre-built image hosted on DockerHub (https://hub.docker.com/r/smarthome2cloud/smarthome-demo/) by running the command below.    
-    `$ docker pull smarthome2cloud/smarthome-demo`
+    * Download the pre-built image hosted on DockerHub (https://hub.docker.com/r/smarthome2cloud/smarthome-gateway/) by running the command below.
+    `$ docker pull smarthome2cloud/smarthome-gateway`
 
 + 3.2 Build the image
     * Under the `smarthome-web-portal` folder, run the command below to build the image. *smarthome2cloud* is the image name and *v1* is the tag of the image.    


### PR DESCRIPTION
* The IoT REST API Server Command-line arguments are enabled in Docker
  and transparently passed through. This allows to tweak its behaviour
  by changing the port and/or enabling https
* The README.md was updated to describe a couple of methods for deploying
  the Home Gateway function

Fix #147 

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>