### PR TITLE
Update to latest versions of iotivity-node and iot-rest-api-server

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get install -y \
 # Install IoTivity build dependencies
 RUN apt-get install -y \
     libboost-dev libboost-program-options-dev libboost-thread-dev \
-    uuid-dev libexpat1-dev libglib2.0-dev
+    uuid-dev libexpat1-dev libglib2.0-dev libsqlite3-dev \
+    libcurl4-gnutls-dev
 
 # Install npm, nodejs
 RUN apt-get install -y npm nodejs-legacy

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iot-rest-api-server": "^0.3.0",
+    "iot-rest-api-server": "0.4",
     "express": "*",
     "websocket": "*",
     "http": "*"

--- a/ocf-servers/Dockerfile
+++ b/ocf-servers/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get install -y \
 # Install IoTivity build dependencies
 RUN apt-get install -y \
     libboost-dev libboost-program-options-dev libboost-thread-dev \
-    uuid-dev libexpat1-dev libglib2.0-dev
+    uuid-dev libexpat1-dev libglib2.0-dev libsqlite3-dev \
+    libcurl4-gnutls-dev
 
 # Install npm, nodejs
 RUN apt-get install -y npm nodejs-legacy

--- a/ocf-servers/package.json
+++ b/ocf-servers/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iotivity-node": "^1.2.0-2",
+    "iotivity-node": "^1.2.1-1",
     "express": "*",
     "websocket": "*"
  }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iot-rest-api-server": "^0.3.0",
+    "iot-rest-api-server": "0.4",
     "express": "*",
     "websocket": "*",
     "http": "*",


### PR DESCRIPTION
This updates both iotivity-node and the iot-rest-api-server to their
latest versions and allow for automatic updates when there is no API
breakage.

The iot-rest-api-server project will increase the patch number when
doing updates without breaking the API.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>