### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.a
+.o
+.swp
+.log
+npm-debug.log*
+node_modules
+outdir
+outdir-*


### PR DESCRIPTION
Initial .gitignore file that filters out output files from node.js
and the Zephyr build output.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>