### PR TITLE
Dockerfile (and scripts): add license headers

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM ubuntu:16.04
 
 # Allows to set-up HTTP(S) proxy using '--build-arg'

--- a/gateway/start-gateway-in-docker.sh
+++ b/gateway/start-gateway-in-docker.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Print out container IP address
 echo "This container IP address is: `hostname -i`"
 

--- a/ocf-servers/Dockerfile
+++ b/ocf-servers/Dockerfile
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM ubuntu:16.04
 
 # Allows to set-up HTTP(S) proxy using '--build-arg'

--- a/ocf-servers/start-ocf-servers-in-docker.sh
+++ b/ocf-servers/start-ocf-servers-in-docker.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # project home directory
 PROJ_HOME=/opt/SmartHome-Demo
 

--- a/smarthome-web-portal/Dockerfile
+++ b/smarthome-web-portal/Dockerfile
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM ubuntu:16.04
 
 ARG http_proxy


### PR DESCRIPTION
Add license headers (Apache-2.0) to all files used to build the
Docker containers. That includes Dockerfile and some start-up scripts.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>