### PR TITLE
JS OCF Servers: remove unneeded deps from package.json

### DIFF
--- a/ocf-servers/package.json
+++ b/ocf-servers/package.json
@@ -15,8 +15,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iotivity-node": "^1.2.1-1",
-    "express": "*",
-    "websocket": "*"
+    "iotivity-node": "^1.2.1-1"
  }
 }


### PR DESCRIPTION
Remove incorrect dependencies from the package.json file. The
OCF Servers implemented in JS (in ocf-servers/js-servers/) do
*not* require the 'express' module nor the 'websocket' module.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>