### PR TITLE
OCF JS servers: Print device ID when OCF server started

### DIFF
--- a/ocf-servers/js-servers/ambient_light.js
+++ b/ocf-servers/js-servers/ambient_light.js
@@ -160,6 +160,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Illuminance sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/button-toggle.js
+++ b/ocf-servers/js-servers/button-toggle.js
@@ -176,6 +176,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Button pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/button.js
+++ b/ocf-servers/js-servers/button.js
@@ -162,6 +162,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Button pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/buzzer.js
+++ b/ocf-servers/js-servers/buzzer.js
@@ -169,6 +169,8 @@ device.platform = Object.assign(device.platform, {
 
 // Enable presence
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Buzzer sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/environmental_sensor.js
+++ b/ocf-servers/js-servers/environmental_sensor.js
@@ -295,6 +295,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     debuglog('Create environmental sensor resource.');
 
     // Register sensor resource

--- a/ocf-servers/js-servers/fan.js
+++ b/ocf-servers/js-servers/fan.js
@@ -148,6 +148,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Fan sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/gas.js
+++ b/ocf-servers/js-servers/gas.js
@@ -167,6 +167,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Gas sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/led.js
+++ b/ocf-servers/js-servers/led.js
@@ -152,6 +152,8 @@ device.platform = Object.assign(device.platform, {
 
 // Enable presence
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup LED pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/motion.js
+++ b/ocf-servers/js-servers/motion.js
@@ -163,6 +163,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Motion sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/power-uart.js
+++ b/ocf-servers/js-servers/power-uart.js
@@ -350,6 +350,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup uart
     setupHardware();
 

--- a/ocf-servers/js-servers/rgb_led.js
+++ b/ocf-servers/js-servers/rgb_led.js
@@ -230,6 +230,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup RGB LED sensor pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/solar.js
+++ b/ocf-servers/js-servers/solar.js
@@ -281,6 +281,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Solar sensor.
     setupHardware();
 

--- a/ocf-servers/js-servers/switch.js
+++ b/ocf-servers/js-servers/switch.js
@@ -163,6 +163,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup binary switch pin.
     setupHardware();
 

--- a/ocf-servers/js-servers/temperature.js
+++ b/ocf-servers/js-servers/temperature.js
@@ -263,6 +263,8 @@ device.platform = Object.assign(device.platform, {
 });
 
 if (device.device.uuid) {
+    debuglog("Device id: ", device.device.uuid);
+
     // Setup Temperature sensor pin.
     setupHardware();
 


### PR DESCRIPTION
Print device ID in debug messages when OCF server started. The is often helpful to identify the device after resource discovery from client.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>