### PR TITLE
package.json: remove bogus dependency on node.js 'http' module.

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "iot-rest-api-server": "0.6.0",
     "express": "*",
-    "websocket": "*",
-    "http": "*"
+    "websocket": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "iot-rest-api-server": "0.6.0",
     "express": "*",
     "websocket": "*",
-    "http": "*",
     "noble": "^1.6.0",
     "lodash.mergewith": "^4.0.0",
     "lodash.assignin": "^4.0.0",


### PR DESCRIPTION
The 'package.json' file for the Gateway function lists 'http' as
a dependency. This has the effect of installing
https://www.npmjs.com/package/http instead making us use
node.js' built-in http module. This is undesirable as this
external module hasn't been maintained or updated for 4 years.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>