### PR TITLE
smarthome-web-portal: enable displaying of *all* sensors

### DIFF
--- a/smarthome-web-portal/RestClient/Resource.py
+++ b/smarthome-web-portal/RestClient/Resource.py
@@ -66,8 +66,8 @@ class Resource(object):
                         elif bm == 3 and not secure:
                             observable = True
 
-                    if rt and not rt.startswith("oic.wk") and href \
-                            and (href.startswith("/a/") or href.startswith("/brillo/")):
+                    if rt and not href.startswith("/oic/") and \
+                            not href.startswith("/introspection"):
                         sensors.append((item['di'], href, rt, observable))
                     else:
                         # ignore the wrong or unregistered json types


### PR DESCRIPTION
This patch will make the Cloud Portal display all OCF servers
discovered even when their path ('href') does not start with "/a/".
We are still filtering out from the list of devices discovered
those whose 'href' starts with "/oic/" or "/introspection" as
they are not representing OCF servers (see also the OCF specs
for more details)

Fix #181 

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>